### PR TITLE
OS X: Use @rpath in installed dylib id

### DIFF
--- a/examples/tools/tools.pro
+++ b/examples/tools/tools.pro
@@ -1,5 +1,7 @@
 TEMPLATE = lib
 
+include(../../variables.pri)
+
 TARGET = kdreporttesttools
 
 CONFIG(debug, debug|release) {
@@ -14,10 +16,6 @@ staticlib {
 # For QAIM::reset()
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x000000
 
-DESTDIR = $${TOP_BUILD_DIR}/lib
-# Workaround for visual studio integration
-win32: DLLDESTDIR = $${TOP_BUILD_DIR}/bin
-
 DEFINES += KDREPORT_BUILD_TESTTOOLS_LIB
 DEPENDPATH += .
 INCLUDEPATH += .
@@ -25,14 +23,3 @@ INCLUDEPATH += .
 # Input
 HEADERS += TableModel.h
 SOURCES += TableModel.cpp
-
-unix {
-  MOC_DIR = .moc
-  OBJECTS_DIR = .obj
-  UI_DIR = .ui
-} else {
-  MOC_DIR = _moc
-  OBJECTS_DIR = _obj
-  UI_DIR = _ui
-}
-

--- a/variables.pri
+++ b/variables.pri
@@ -11,8 +11,8 @@ QT += xml
 solaris-cc:DEFINES += SUN7
 
 win32-msvc*:QMAKE_CXXFLAGS += /GR /EHsc /wd4251
-
 unix:!macx:QMAKE_LFLAGS += -Wl,-no-undefined
+macx:QMAKE_SONAME_PREFIX = @rpath
 
 CONFIG += depend_includepath
 


### PR DESCRIPTION
Currently the dylib id uses just the library file name:
```
$ otool -L
/Users/.../install/lib/libkdreports.dylib
/Users/.../install/lib/libkdreports.dylib:
        libkdreports.1.dylib (compatibility version 1.7.0, current
version 1.7.50)
```

After this patch it is prefixed with @rpath