### PR TITLE
Add basic qmake out of the box usage

### DIFF
--- a/autogen/autogen.py
+++ b/autogen/autogen.py
@@ -63,7 +63,7 @@ def checkVCS( sourceDirectory ):
 
 	return ( repositoryRevision, isTagged )
 
-def autogen(project, version, subprojects, prefixed, forwardHeaderMap = {}, steps=["generate-cpack", "generate-configure", "generate-forward-headers"], installPrefix="$$INSTALL_PREFIX", policyVersion = 1):
+def autogen(project, version, subprojects, prefixed, forwardHeaderMap = {}, steps = ["generate-cpack", "generate-configure", "generate-forward-headers"], installPrefix="$$INSTALL_PREFIX", policyVersion = 1):
 	global __policyVersion
 	__policyVersion = policyVersion
 	sourceDirectory = os.path.abspath( os.path.dirname( os.path.dirname( __file__ ) ) )
@@ -95,7 +95,7 @@ def autogen(project, version, subprojects, prefixed, forwardHeaderMap = {}, step
 	includePath = os.path.join( sourceDirectory, "include" )
 	srcPath = os.path.join( sourceDirectory, "src" )
 
-	if subprojects and "generate-cpack" in steps:
+	if subprojects and "generate-forward-headers" in steps:
 		forwardHeaderGenerator = ForwardHeaderGenerator( 
 			copy = True, path = sourceDirectory, includepath = includePath, srcpath = srcPath,
 			project = project, subprojects = subprojects, prefix = installPrefix, prefixed = prefixed,
@@ -108,6 +108,10 @@ def autogen(project, version, subprojects, prefixed, forwardHeaderMap = {}, step
 	with file( ".license.accepted", 'a' ):
 		os.utime( ".license.accepted", None )
 	print( "-- License marked as accepted." )
+
+	if steps == ["generate-forward-headers"]:
+		sys.stdout.flush()
+		return
 
 	print( "-- Wrote build files to: {0}".format( buildDirectory ) )
 	print( "-- Now running configure script." )

--- a/gen-forward-headers.py
+++ b/gen-forward-headers.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+from autogen.autogen import autogen
+
+project = "KDReports"
+version = "1.7.50"
+subprojects = ["KDReports"]
+prefixed = True
+
+autogen(project, version, subprojects, prefixed, steps = ["generate-forward-headers"], policyVersion = 2)

--- a/kdreports.pro
+++ b/kdreports.pro
@@ -1,5 +1,7 @@
 TEMPLATE = subdirs
-SUBDIRS  = src examples include
+system($$system_path(./gen-forward-headers.py))|error("Can't generate forward headers, please ensure python is available from this shell.")
+SUBDIRS  = include src
+!no_examples: SUBDIRS += examples
 unittests: SUBDIRS += unittests
 CONFIG   += ordered
 VERSION  = 1.7.50


### PR DESCRIPTION
Forward headers are now automatically generated when qmake'ing the project and examples can be disabled using CONFIG+=no_examples. The forward headers are unconditionally regenerated at each qmake call, while that is not optimal, it is sufficient most of the time as the project file is likely not to be modified.