### PR TITLE
Find KDChart when specified from command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,19 @@
 #  Build the examples.
 #  Default=true
 #
+# -DKDChart_ROOT=[KDChart install path]
+#  Enable KDChart support.
+#  Default=off
+
 cmake_minimum_required(VERSION 2.8.12)
 if(POLICY CMP0020)
   cmake_policy(SET CMP0020 NEW)
 endif()
 if(POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)
+endif()
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 if("${CMAKE_INSTALL_PREFIX}" STREQUAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,6 @@
 #  Build the examples.
 #  Default=true
 #
-# -DKDChart_ROOT=[KDChart install path]
-#  Enable KDChart support.
-#  Default=off
 
 cmake_minimum_required(VERSION 2.8.12)
 if(POLICY CMP0020)
@@ -31,6 +28,7 @@ if(POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)
 endif()
 if(POLICY CMP0074)
+  # Since 3.12 tells find_package to look for <Package>_ROOT variables.
   cmake_policy(SET CMP0074 NEW)
 endif()
 


### PR DESCRIPTION
With policy CMP0074 enabled we can specify KDChart_ROOT with the KDChart install folder when using CMake 3.17