### PR TITLE
Fix most Qt 5.15 warnings

### DIFF
--- a/src/KDReports/KDReportsHeader.cpp
+++ b/src/KDReports/KDReportsHeader.cpp
@@ -30,6 +30,7 @@
 #include <QDebug>
 #include <QDate>
 #include <QTime>
+#include <QLocale>
 #include <QTextBlock>
 
 KDReports::Header::Header( KDReports::Report* report )
@@ -75,22 +76,21 @@ QString variableValue( int pageNumber, KDReports::Report* report, VariableType t
         return QDate::currentDate().toString( Qt::TextDate );
     case ISODate:
         return QDate::currentDate().toString( Qt::ISODate );
-    case LocaleDate:
-        return QDate::currentDate().toString( Qt::LocaleDate );
     case SystemLocaleShortDate:
-        return QDate::currentDate().toString( Qt::SystemLocaleShortDate );
+        return QLocale::system().toString(QDate::currentDate(), QLocale::ShortFormat);
     case SystemLocaleLongDate:
-        return QDate::currentDate().toString( Qt::SystemLocaleLongDate );
+        return QLocale::system().toString(QDate::currentDate(), QLocale::LongFormat);
+    case LocaleDate:
     case DefaultLocaleShortDate:
-        return QDate::currentDate().toString( Qt::DefaultLocaleShortDate );
+        return QLocale().toString(QDate::currentDate(), QLocale::ShortFormat);
     case DefaultLocaleLongDate:
-        return QDate::currentDate().toString( Qt::DefaultLocaleLongDate );
+        return QLocale().toString(QDate::currentDate(), QLocale::LongFormat);
     case TextTime:
         return QTime::currentTime().toString( Qt::TextDate );
     case ISOTime:
         return QTime::currentTime().toString( Qt::ISODate );
     case LocaleTime:
-        return QTime::currentTime().toString( Qt::LocaleDate );
+        return QLocale().toString(QTime::currentTime(), QLocale::ShortFormat);
     default:
         qWarning() << "Program error, variable" << type << "not implemented";
     }

--- a/src/KDReports/KDReportsPreviewWidget.cpp
+++ b/src/KDReports/KDReportsPreviewWidget.cpp
@@ -402,7 +402,11 @@ void KDReports::PreviewWidgetPrivate::pageCountChanged()
         //qDebug() << "Report has" << m_pageCount << "pages";
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
     int numberWidth = 20 + pageNumber->fontMetrics().width( QString::number( m_pageCount ) );
+#else
+    int numberWidth = 20 + pageNumber->fontMetrics().horizontalAdvance( QString::number( m_pageCount ) );
+#endif
     pageNumber->setMinimumWidth( numberWidth );
     pageNumber->setMaximumWidth( numberWidth );
     pageCount->setText( QString::fromLatin1( " / " ) + QString::number( m_pageCount ) );


### PR DESCRIPTION
Fix most warnings from #20 skipping only loadFromXML changes that are still open about the whitespace characters.