### PR TITLE
Fixed python bindings build for Qt6

### DIFF
--- a/python/PyKDReports/glue.cpp
+++ b/python/PyKDReports/glue.cpp
@@ -17,9 +17,9 @@
 // @snippet abstract_table_element_default_font
 
 bool p;
-%RETURN_TYPE retval = %CPPSELF.%FUNCTION_NAME(&p);
+auto retval = %CPPSELF.%FUNCTION_NAME(&p);
 %PYARG_0 = PyTuple_New(2);
-PyTuple_SET_ITEM(%PYARG_0, 0, %CONVERTTOPYTHON[%RETURN_TYPE](retval));
+PyTuple_SET_ITEM(%PYARG_0, 0, %CONVERTTOPYTHON[QFont](retval));
 PyTuple_SET_ITEM(%PYARG_0, 1, %CONVERTTOPYTHON[bool](p));
 
 // @snippet abstract_table_element_default_font

--- a/python/PyKDReports/typesystem_kdreports.xml
+++ b/python/PyKDReports/typesystem_kdreports.xml
@@ -15,7 +15,7 @@
 
         <object-type name="AbstractTableElement">
             <modify-function signature="defaultFont(bool*)const" remove="all" />
-            <add-function signature="defaultFont()" return-type="(QFont, bool)">
+            <add-function signature="defaultFont()" return-type="PyObject*">
                 <inject-code class="target" position="beginning" file="glue.cpp" snippet="abstract_table_element_default_font"/>
             </add-function>
         </object-type>
@@ -30,7 +30,7 @@
             <enum-type name="ReportMode" />
             <enum-type name="TableBreakingPageOrder" />
             <modify-function signature="getMargins(qreal *, qreal *, qreal *, qreal *) const" remove="all" />
-            <add-function signature="getMargins()" return-type="(qreal, qreal, qreal, qreal)">
+            <add-function signature="getMargins()" return-type="PyObject*">
                 <inject-code class="target" position="beginning" file="glue.cpp" snippet="report_get_margins"/>
             </add-function>
         </object-type>
@@ -42,8 +42,16 @@
         <object-type name="ImageElement" />
         <object-type name="TableElement" />
         <object-type name="TextElement" />
-        <object-type name="AutoTableElement" />
-        <object-type name="ChartElement" />
+        <object-type name="AutoTableElement">
+            <!-- FIXME: this contrcutor causes crash on shiboken6 generator (vr. 6.1.2) -->
+            <modify-function signature="AutoTableElement(QAbstractItemModel *)" remove="all" />
+            <enum-type name="Role" />
+        </object-type>
+        <object-type name="ChartElement">
+            <!-- FIXME: this contrcutor causes crash on shiboken6 generator (vr. 6.1.2) -->
+            <modify-function signature="ChartElement(QAbstractItemModel *)" remove="all" />
+        </object-type>
+
         <object-type name="Header" />
 
         <value-type name="ErrorDetails" />

--- a/src/KDReports/KDReportsAutoTableElement.h
+++ b/src/KDReports/KDReportsAutoTableElement.h
@@ -151,7 +151,7 @@ public:
      */
     Element *clone() const override;
 
-    enum {
+    enum Role {
         DecorationAlignmentRole = 0x2D535FB1, ///< This model role allows to specify whether the icon should go before the text (Qt::AlignLeft) or after the text (Qt::AlignRight).
         NonBreakableLinesRole = 0x2D535FB2 ///< This model role allows to specify that line-breaking is not allowed in this table cell. \since 1.7.
     };


### PR DESCRIPTION
- Added bindings for missing enum AutoTableElement::Role
- Used PyObject* as return type for function modification that returns tuple
- Removed bindings for constructors with signature (QAbstractItemModel *) this is crashing shiboken vr. 6.1.2, require fix