### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,22 +5,22 @@ Source: https://www.github.com/KDAB/KDReports
 
 #misc source code
 Files: *.qrc *.ui *.xml *.csv *.bat *.ts
-Copyright: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #artwork
 Files: images/*.png images/*.svg docs/api/*.png pics/*.png examples/*/*.png examples/*/*.jpg python/examples/*/*.jpg python/examples/*/*.png python/examples-qt6/*.jpg python/examples-qt6/*/*.png
-Copyright: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc documentation
 Files: *md *.txt *.html docs/manual/*.pdf
-Copyright: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc config files
 Files: .pre-commit-config.yaml .codespellrc .krazy .cmake-format.py .clang-format .clang-tidy .clazy .gitignore .mdlrc .mdlrc.rb .pep8 .pylintrc appveyor.yml docs/api/Doxyfile.cmake distro/*
-Copyright: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 
 #3rdparty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 License
 =======
-The KD Reports Software is Copyright 2007-2023 Klarälvdalens Datakonsult AB (KDAB),
+The KD Reports Software is © 2007 Klarälvdalens Datakonsult AB (KDAB),
 and is available under the terms of the MIT license.
 
 See the full license text in the LICENSES folder.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please submit your contributions or issue reports from our GitHub space at
 
 ## License
 
-The KD Reports Software is Copyright 2007-2023 Klarälvdalens Datakonsult AB (KDAB),
+The KD Reports Software is © 2007 Klarälvdalens Datakonsult AB (KDAB),
 and is available under the terms of the [MIT](LICENSES/MIT.txt) license.
 
 Contact KDAB at <info@kdab.com> for any licensing queries.

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/footer.html
+++ b/docs/api/footer.html
@@ -1,7 +1,7 @@
     <hr>
     <div style="float: left;">
       <img src="kdab-logo-22x22.png">
-      <font style="font-weight: bold;">&copy; 2007-2023 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
+      <font style="font-weight: bold;">&copy; Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
       <br>
 	    "The Qt, C++ and OpenGL Experts"<br>
 	    <a href="https://www.kdab.com/">https://www.kdab.com/</a>

--- a/examples/BigImage/BigImage.cpp
+++ b/examples/BigImage/BigImage.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/BigImage/CMakeLists.txt
+++ b/examples/BigImage/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/ChartXML/CMakeLists.txt
+++ b/examples/ChartXML/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/ChartXML/ChartXML.cpp
+++ b/examples/ChartXML/ChartXML.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Database/CMakeLists.txt
+++ b/examples/Database/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Database/Database.cpp
+++ b/examples/Database/Database.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DatabaseXML/CMakeLists.txt
+++ b/examples/DatabaseXML/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/DatabaseXML/DatabaseXML.cpp
+++ b/examples/DatabaseXML/DatabaseXML.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/CMakeLists.txt
+++ b/examples/DemoWasm/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/DemoWasm/ResultModel.cpp
+++ b/examples/DemoWasm/ResultModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/ResultModel.h
+++ b/examples/DemoWasm/ResultModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/TableModel.cpp
+++ b/examples/DemoWasm/TableModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/TableModel.h
+++ b/examples/DemoWasm/TableModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/kdreportswindow.cpp
+++ b/examples/DemoWasm/kdreportswindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/kdreportswindow.h
+++ b/examples/DemoWasm/kdreportswindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/main.cpp
+++ b/examples/DemoWasm/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DemoWasm/tools_export.h
+++ b/examples/DemoWasm/tools_export.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HelloWorld/CMakeLists.txt
+++ b/examples/HelloWorld/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/HelloWorld/HelloWorld.cpp
+++ b/examples/HelloWorld/HelloWorld.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HelloWorldXML/CMakeLists.txt
+++ b/examples/HelloWorldXML/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/HelloWorldXML/HelloWorldXML.cpp
+++ b/examples/HelloWorldXML/HelloWorldXML.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Labels/CMakeLists.txt
+++ b/examples/Labels/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Labels/Labels.cpp
+++ b/examples/Labels/Labels.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Letter/CMakeLists.txt
+++ b/examples/Letter/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Letter/Letter.cpp
+++ b/examples/Letter/Letter.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/LongTextReport/CMakeLists.txt
+++ b/examples/LongTextReport/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/LongTextReport/LongTextReport.cpp
+++ b/examples/LongTextReport/LongTextReport.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/MailMergeXML/CMakeLists.txt
+++ b/examples/MailMergeXML/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/MailMergeXML/MailMergeXML.cpp
+++ b/examples/MailMergeXML/MailMergeXML.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/PriceList/CMakeLists.txt
+++ b/examples/PriceList/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/PriceList/PriceList.cpp
+++ b/examples/PriceList/PriceList.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/PriceListXML/CMakeLists.txt
+++ b/examples/PriceListXML/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/PriceListXML/PriceListXML.cpp
+++ b/examples/PriceListXML/PriceListXML.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ReferenceReport/CMakeLists.txt
+++ b/examples/ReferenceReport/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/ReferenceReport/ReferenceReport.cpp
+++ b/examples/ReferenceReport/ReferenceReport.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ReferenceReport/ResultModel.cpp
+++ b/examples/ReferenceReport/ResultModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ReferenceReport/ResultModel.h
+++ b/examples/ReferenceReport/ResultModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ReportSection/CMakeLists.txt
+++ b/examples/ReportSection/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/ReportSection/ReportSection.cpp
+++ b/examples/ReportSection/ReportSection.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/SpreadsheetAutoTable/CMakeLists.txt
+++ b/examples/SpreadsheetAutoTable/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/SpreadsheetAutoTable/SpreadsheetAutoTable.cpp
+++ b/examples/SpreadsheetAutoTable/SpreadsheetAutoTable.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/tools/CMakeLists.txt
+++ b/examples/tools/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/tools/TableModel.cpp
+++ b/examples/tools/TableModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/tools/TableModel.h
+++ b/examples/tools/TableModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/tools/tools_export.h
+++ b/examples/tools/tools_export.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/kdchart.pri
+++ b/kdchart.pri
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/kdreports.pri
+++ b/kdreports.pri
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/PyKDReports/CMakeLists.txt
+++ b/python/PyKDReports/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/PyKDReports/__init__.py.cmake
+++ b/python/PyKDReports/__init__.py.cmake
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/PyKDReports/glue.cpp
+++ b/python/PyKDReports/glue.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/python/PyKDReports/kdreports_global.h
+++ b/python/PyKDReports/kdreports_global.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/python/examples-qt6/HelloWorld/HelloWorld.py
+++ b/python/examples-qt6/HelloWorld/HelloWorld.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/Labels/Labels.py
+++ b/python/examples-qt6/Labels/Labels.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/PriceList/PriceList.py
+++ b/python/examples-qt6/PriceList/PriceList.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/PriceList/TableModel.py
+++ b/python/examples-qt6/PriceList/TableModel.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/HelloWorld/HelloWorld.py
+++ b/python/examples/HelloWorld/HelloWorld.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/Labels/Labels.py
+++ b/python/examples/Labels/Labels.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/PriceList/PriceList.py
+++ b/python/examples/PriceList/PriceList.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/PriceList/TableModel.py
+++ b/python/examples/PriceList/TableModel.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/tests/config.py.cmake
+++ b/python/tests/config.py.cmake
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/tests/tst_importModule.py
+++ b/python/tests/tst_importModule.py
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDReports/KDReports.h
+++ b/src/KDReports/KDReports.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsAbstractReportLayout.cpp
+++ b/src/KDReports/KDReportsAbstractReportLayout.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsAbstractReportLayout_p.h
+++ b/src/KDReports/KDReportsAbstractReportLayout_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsAbstractTableElement.cpp
+++ b/src/KDReports/KDReportsAbstractTableElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsAbstractTableElement.h
+++ b/src/KDReports/KDReportsAbstractTableElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsAutoTableElement.cpp
+++ b/src/KDReports/KDReportsAutoTableElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsAutoTableElement.h
+++ b/src/KDReports/KDReportsAutoTableElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsCell.cpp
+++ b/src/KDReports/KDReportsCell.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsCell.h
+++ b/src/KDReports/KDReportsCell.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsChartElement.cpp
+++ b/src/KDReports/KDReportsChartElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsChartElement.h
+++ b/src/KDReports/KDReportsChartElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsChartTextObject.cpp
+++ b/src/KDReports/KDReportsChartTextObject.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsChartTextObject_p.h
+++ b/src/KDReports/KDReportsChartTextObject_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsElement.cpp
+++ b/src/KDReports/KDReportsElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsElement.h
+++ b/src/KDReports/KDReportsElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsElementData_p.h
+++ b/src/KDReports/KDReportsElementData_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsErrorDetails.cpp
+++ b/src/KDReports/KDReportsErrorDetails.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsErrorDetails.h
+++ b/src/KDReports/KDReportsErrorDetails.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsErrorDetails_p.h
+++ b/src/KDReports/KDReportsErrorDetails_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsFontScaler.cpp
+++ b/src/KDReports/KDReportsFontScaler.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsFontScaler_p.h
+++ b/src/KDReports/KDReportsFontScaler_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsFrame.cpp
+++ b/src/KDReports/KDReportsFrame.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsFrame.h
+++ b/src/KDReports/KDReportsFrame.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsGlobal.h
+++ b/src/KDReports/KDReportsGlobal.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHLineElement.cpp
+++ b/src/KDReports/KDReportsHLineElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHLineElement.h
+++ b/src/KDReports/KDReportsHLineElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHLineTextObject.cpp
+++ b/src/KDReports/KDReportsHLineTextObject.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHLineTextObject_p.h
+++ b/src/KDReports/KDReportsHLineTextObject_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHeader.cpp
+++ b/src/KDReports/KDReportsHeader.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHeader.h
+++ b/src/KDReports/KDReportsHeader.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHeader_p.h
+++ b/src/KDReports/KDReportsHeader_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHtmlElement.cpp
+++ b/src/KDReports/KDReportsHtmlElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsHtmlElement.h
+++ b/src/KDReports/KDReportsHtmlElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsImageElement.cpp
+++ b/src/KDReports/KDReportsImageElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsImageElement.h
+++ b/src/KDReports/KDReportsImageElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsLayoutHelper.cpp
+++ b/src/KDReports/KDReportsLayoutHelper.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsLayoutHelper_p.h
+++ b/src/KDReports/KDReportsLayoutHelper_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsMainTable.cpp
+++ b/src/KDReports/KDReportsMainTable.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsMainTable.h
+++ b/src/KDReports/KDReportsMainTable.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsPreviewDialog.cpp
+++ b/src/KDReports/KDReportsPreviewDialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsPreviewDialog.h
+++ b/src/KDReports/KDReportsPreviewDialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsPreviewWidget.cpp
+++ b/src/KDReports/KDReportsPreviewWidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsPreviewWidget.h
+++ b/src/KDReports/KDReportsPreviewWidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsReport.cpp
+++ b/src/KDReports/KDReportsReport.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsReport.h
+++ b/src/KDReports/KDReportsReport.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsReportBuilder.cpp
+++ b/src/KDReports/KDReportsReportBuilder.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsReportBuilder_p.h
+++ b/src/KDReports/KDReportsReportBuilder_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsReport_p.h
+++ b/src/KDReports/KDReportsReport_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsSpreadsheetReportLayout.cpp
+++ b/src/KDReports/KDReportsSpreadsheetReportLayout.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsSpreadsheetReportLayout_p.h
+++ b/src/KDReports/KDReportsSpreadsheetReportLayout_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableBreakingLogic.cpp
+++ b/src/KDReports/KDReportsTableBreakingLogic.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableBreakingLogic_p.h
+++ b/src/KDReports/KDReportsTableBreakingLogic_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableBreakingSettingsDialog.cpp
+++ b/src/KDReports/KDReportsTableBreakingSettingsDialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableBreakingSettingsDialog.h
+++ b/src/KDReports/KDReportsTableBreakingSettingsDialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableElement.cpp
+++ b/src/KDReports/KDReportsTableElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableElement.h
+++ b/src/KDReports/KDReportsTableElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableLayout.cpp
+++ b/src/KDReports/KDReportsTableLayout.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTableLayout_p.h
+++ b/src/KDReports/KDReportsTableLayout_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextDocReportLayout.cpp
+++ b/src/KDReports/KDReportsTextDocReportLayout.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextDocReportLayout_p.h
+++ b/src/KDReports/KDReportsTextDocReportLayout_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextDocument.cpp
+++ b/src/KDReports/KDReportsTextDocument.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextDocumentData.cpp
+++ b/src/KDReports/KDReportsTextDocumentData.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextDocumentData_p.h
+++ b/src/KDReports/KDReportsTextDocumentData_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextDocument_p.h
+++ b/src/KDReports/KDReportsTextDocument_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextElement.cpp
+++ b/src/KDReports/KDReportsTextElement.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsTextElement.h
+++ b/src/KDReports/KDReportsTextElement.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsUnit.h
+++ b/src/KDReports/KDReportsUnit.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsVariableType.h
+++ b/src/KDReports/KDReportsVariableType.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsXmlElementHandler.cpp
+++ b/src/KDReports/KDReportsXmlElementHandler.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsXmlElementHandler.h
+++ b/src/KDReports/KDReportsXmlElementHandler.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsXmlHelper.cpp
+++ b/src/KDReports/KDReportsXmlHelper.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsXmlHelper.h
+++ b/src/KDReports/KDReportsXmlHelper.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsXmlParser.cpp
+++ b/src/KDReports/KDReportsXmlParser.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReports/KDReportsXmlParser_p.h
+++ b/src/KDReports/KDReportsXmlParser_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDReportsConfig.cmake.in
+++ b/src/KDReportsConfig.cmake.in
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/ElementCopying/CMakeLists.txt
+++ b/unittests/ElementCopying/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/ElementCopying/ElementCopying.cpp
+++ b/unittests/ElementCopying/ElementCopying.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/Headers/CMakeLists.txt
+++ b/unittests/Headers/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/Headers/Headers.cpp
+++ b/unittests/Headers/Headers.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/InThread/CMakeLists.txt
+++ b/unittests/InThread/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/InThread/InThread.cpp
+++ b/unittests/InThread/InThread.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/PageLayout/CMakeLists.txt
+++ b/unittests/PageLayout/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/PageLayout/PageLayout.cpp
+++ b/unittests/PageLayout/PageLayout.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/SpreadsheetMode/CMakeLists.txt
+++ b/unittests/SpreadsheetMode/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/SpreadsheetMode/SpreadsheetMode.cpp
+++ b/unittests/SpreadsheetMode/SpreadsheetMode.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/TableBreakingLogic/CMakeLists.txt
+++ b/unittests/TableBreakingLogic/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/TableBreakingLogic/TableBreakingTest.cpp
+++ b/unittests/TableBreakingLogic/TableBreakingTest.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/TextDocument/CMakeLists.txt
+++ b/unittests/TextDocument/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/TextDocument/TextDocument.cpp
+++ b/unittests/TextDocument/TextDocument.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/XmlParser/CMakeLists.txt
+++ b/unittests/XmlParser/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Reports library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/XmlParser/TestXmlElementHandler.cpp
+++ b/unittests/XmlParser/TestXmlElementHandler.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/XmlParser/TestXmlElementHandler.h
+++ b/unittests/XmlParser/TestXmlElementHandler.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/XmlParser/XmlParser.cpp
+++ b/unittests/XmlParser/XmlParser.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Reports library.
 **
-** SPDX-FileCopyrightText: 2007-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2007 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **


### PR DESCRIPTION
For individual files: use year of file creation
For entire project:
  remove year from the statement
  use the © where feasible

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code