### PR TITLE
use find_package

### DIFF
--- a/src/KDReportsConfig.cmake.in
+++ b/src/KDReportsConfig.cmake.in
@@ -9,10 +9,11 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Qt@Qt_VERSION_MAJOR@Core @QT_MIN_VERSION@)
-find_dependency(Qt@Qt_VERSION_MAJOR@Widgets @QT_MIN_VERSION@)
-find_dependency(Qt@Qt_VERSION_MAJOR@PrintSupport @QT_MIN_VERSION@)
-find_dependency(Qt@Qt_VERSION_MAJOR@Xml @QT_MIN_VERSION@)
+find_package(Qt@Qt_VERSION_MAJOR@ @Qt_VERSION_MAJOR@.0.0 COMPONENTS Core REQUIRED)
+find_package(Qt@Qt_VERSION_MAJOR@ @Qt_VERSION_MAJOR@.0.0 COMPONENTS Widgets REQUIRED)
+find_package(Qt@Qt_VERSION_MAJOR@ @Qt_VERSION_MAJOR@.0.0 COMPONENTS PrintSupport REQUIRED)
+find_package(Qt@Qt_VERSION_MAJOR@ @Qt_VERSION_MAJOR@.0.0 COMPONENTS Xml REQUIRED)
+
 
 if (@KDChart_FOUND@)
     find_dependency(KDChart)


### PR DESCRIPTION
find_dependency not work on manjaro qt 6.7.0 or 6.7.1 

I test it with qt5 and qt6 that work.

