### PR TITLE
Build for Qt6 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #
 # -DKDReports_QT6=[true|false]
 #  Build against Qt6 rather than Qt5
-#  Default=false (Qt5 will be used even if Qt6 is available)
+#  Default=true
 #
 # -DKDReports_STATIC=[true|false]
 #  Build static libraries
@@ -80,7 +80,7 @@ set(${PROJECT_NAME}_SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
 
 include(FeatureSummary)
 
-option(${PROJECT_NAME}_QT6 "Build against Qt 6" OFF)
+option(${PROJECT_NAME}_QT6 "Build against Qt 6" ON)
 option(${PROJECT_NAME}_STATIC "Build statically" OFF)
 option(${PROJECT_NAME}_TESTS "Build the tests" ON)
 option(${PROJECT_NAME}_EXAMPLES "Build the examples" ON)

--- a/distro/qt5-debian.rules
+++ b/distro/qt5-debian.rules
@@ -1,3 +1,4 @@
 #!/usr/bin/make -f
+DEB_CMAKE_EXTRA_FLAGS = -DKDReports_QT6=False -DCMAKE_BUILD_TYPE=Release
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk

--- a/distro/qt5-kdreports.spec
+++ b/distro/qt5-kdreports.spec
@@ -49,7 +49,7 @@ develop programs using kdreports.
 %setup -q
 
 %build
-cmake . -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+cmake . -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDReports_QT6=False
 %__make %{?_smp_mflags}
 
 %post -p /sbin/ldconfig

--- a/docs/CHANGES_2_4.txt
+++ b/docs/CHANGES_2_4.txt
@@ -3,7 +3,7 @@ What is new in KD Reports 2.4
 
 General:
 --------
-*
+* KDReports now looks for Qt6 by default, rather than Qt5. If your Qt5 build broke, pass -DKDReports_QT6=OFF to CMake.
 
 Bugfixes:
 -------------


### PR DESCRIPTION
If your Qt5 build broke, pass -DKDReports_QT6=OFF to CMake.