### PR TITLE
ci: Build against both asan and ubsan Qt

### DIFF
--- a/.github/workflows/build-sanitizers.yml
+++ b/.github/workflows/build-sanitizers.yml
@@ -24,7 +24,7 @@ jobs:
         preset: ['dev-asan']
         include:
           - preset: dev-asan
-            qt-flavor: asan
+            qt-flavor: asan_ubsan
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The KDReports asan preset already enables both for KDReports itself. Now the Qt it builds against also has both.