### PR TITLE
ci: bump to 6.12-beta1

### DIFF
--- a/.github/workflows/build-sanitizers.yml
+++ b/.github/workflows/build-sanitizers.yml
@@ -29,10 +29,14 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
 
+      - name: Install dependencies
+        run: |
+          sudo apt install libwayland-dev wayland-protocols -y
+
       - name: Setup Sanitized Qt
         uses: KDABLabs/sanitized-qt-action@v1
         with:
-          qt-tag: "v6.11.0-beta2"
+          qt-tag: "v6.12.0-beta1" # Bump to latest freely
           qt-flavor: ${{ matrix.qt-flavor }}
 
       - name: Configure project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
         config:
           - qt_version: "5.15"
           - qt_version: "6.6.0"
-          - qt_version: "6.10.*" # Bump to latest freely
 
         exclude:
           # 5.15.2 is intel-only, do not attempt on ARM


### PR DESCRIPTION
Removed the old "latest" Qt which was still at 6.10. Not needed since we're testing the latest in build-sanitizers.yml